### PR TITLE
avoid GDAL from ubuntugis, remove sen2cor binary after installation

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-# This docker is based on ubuntu 14.04
+# This docker is based on ubuntu 16.04
 # The objective is to run sen2cor in this docker
 FROM ubuntu:xenial
 
@@ -7,33 +7,15 @@ ENV DEBIAN_FRONTEND noninteractive
 ARG SEN2COR_VERSION='2.4.0'
 ARG GOSU_VERSION='1.9'
 ARG SEN2COR="Sen2Cor-${SEN2COR_VERSION}-Linux64.run"
-RUN sed 's/main$/main universe multiverse/' -i /etc/apt/sources.list && \
-    apt-get update && \
-    apt-get -y upgrade && \
-    apt-get install -y \
-        build-essential \
-        python \
-        python-dev \
-        python-distribute \
-        python-pip \
-        software-properties-common && \
-    add-apt-repository ppa:ubuntugis/ubuntugis-unstable && \
-    apt-get update && \
-    apt-get -y upgrade && \
-    apt-get install -y \
-        gdal-bin \
-        libgdal-dev \
-        python-gdal \
-        python-pyproj \
-        libxt6 \
-        libxpm4 \
-        libxmu6 \
-        wget \
+RUN apt-get update && apt-get install -y \
+        unzip \
         curl \
-        unzip && \
-    pip install psycopg2 &&\
+        file \
+        wget && \
+    rm -rf /var/lib/apt/lists/* && \
     wget "http://step.esa.int/thirdparties/sen2cor/${SEN2COR_VERSION}/${SEN2COR}" && \
     bash ${SEN2COR} && \
+    rm ${SEN2COR} && \
     cp -p /Sen2Cor-${SEN2COR_VERSION}-Linux64/lib/python2.7/site-packages/sen2cor/cfg/L2A_GIPP.xml /root/sen2cor/cfg/L2A_GIPP_without_dem.xml && \
     sed 's:>NONE<:>dem<:' /root/sen2cor/cfg/L2A_GIPP_without_dem.xml >/root/sen2cor/cfg/L2A_GIPP_with_dem.xml && \
     curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \


### PR DESCRIPTION
We tried to reduce the size of the docker image. It is not necessary to install Python and GDAL from UbuntuGIS since both is included in the standalone installer of Sen2Cor. Additionally we remove the installer after installation. The resulting image size is 720MB.